### PR TITLE
Adds a "strict" mode to the validate task.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ either the word "tab", or a number, such as "2" or "4". Default is "4".
 - `prefix` - as per the command line, the prefix used by fields. Default is "".
 - `verbose` - as per the command line, a number from "0" (quiet) to "3" (verbose).
 - `recursive` - whether the source directory should be parsed recursively. Default is "true".
+- `strict` - whether the validate task should fail if beans need regenerating. Default is "false".
 
 #### JodaGenerate
 
@@ -61,5 +62,6 @@ If you do need to configure the plugin, your properties might look like this:
       verbose = 2
       prefix = "_"
       recursive = true // this is the default
+      strict = true
   }
 ```

--- a/src/main/java/org/joda/beans/gradle/JodaBeansExtension.java
+++ b/src/main/java/org/joda/beans/gradle/JodaBeansExtension.java
@@ -36,6 +36,8 @@ public class JodaBeansExtension
   private String indent;
 
   private Boolean recursive;
+  
+  private Boolean strict;
 
 
   public String getSourceDir()
@@ -108,4 +110,16 @@ public class JodaBeansExtension
   {
     this.recursive = recursive;
   }
+  
+  public Boolean isStrict()
+  {
+    return strict;
+  }
+
+
+  public void setStrict( final Boolean strict )
+  {
+    this.strict = strict;
+  }
+
 }

--- a/src/main/java/org/joda/beans/gradle/tasks/AbstractJodaBeansTask.java
+++ b/src/main/java/org/joda/beans/gradle/tasks/AbstractJodaBeansTask.java
@@ -40,7 +40,15 @@ public abstract class AbstractJodaBeansTask extends DefaultTask
   private static final String DEFAULT_INDENT = "4";
 
   private static final String DEFAULT_STRING_VALUE = "";
-
+  
+  private static final boolean DEFAULT_STRICT_VALUE = false;
+  
+  private static final String GROUP = "JodaBeans";
+  
+  @Override
+  public final String getGroup() {
+    return GROUP;
+  }
 
   protected String getSourceDir()
   {
@@ -75,12 +83,18 @@ public abstract class AbstractJodaBeansTask extends DefaultTask
     return ((JodaBeansExtension) getProject().getExtensions().getByName( JodaBeansExtension.ID )).getVerbose();
   }
 
-
   protected boolean operateRecursive()
   {
     final Boolean recursive =
             ((JodaBeansExtension) getProject().getExtensions().getByName( JodaBeansExtension.ID )).getRecursive();
     return recursive != null ? recursive : true;
+  }
+
+  protected boolean isStrict()
+  {
+    final Boolean strict = 
+           ((JodaBeansExtension) getProject().getExtensions().getByName( JodaBeansExtension.ID )).isStrict();
+    return strict != null ? strict : DEFAULT_STRICT_VALUE;
   }
 
 
@@ -102,7 +116,6 @@ public abstract class AbstractJodaBeansTask extends DefaultTask
     catch( final Exception ex )
     {
       getLogger().error( "Skipping as joda-beans is not in the project compile classpath" );
-      return;
     }
     final List<String> arguments = buildGeneratorArguments();
     getLogger().debug( "Using arguments " + arguments );

--- a/src/main/java/org/joda/beans/gradle/tasks/Generate.java
+++ b/src/main/java/org/joda/beans/gradle/tasks/Generate.java
@@ -41,4 +41,9 @@ public class Generate extends AbstractJodaBeansTask
   {
     return "generator";
   }
+  
+  @Override
+  public String getDescription() {
+    return "Generates JodaBeans";
+  }
 }

--- a/src/main/java/org/joda/beans/gradle/tasks/Validate.java
+++ b/src/main/java/org/joda/beans/gradle/tasks/Validate.java
@@ -17,6 +17,7 @@ package org.joda.beans.gradle.tasks;
 
 import java.util.List;
 
+import org.gradle.api.GradleException;
 import org.gradle.api.specs.Specs;
 import org.gradle.api.tasks.TaskAction;
 
@@ -54,10 +55,27 @@ public class Validate extends AbstractJodaBeansTask
     return argsList;
   }
 
-
+  
   @Override
   protected String getExecutionType()
   {
     return "validator";
   }
+  
+  @Override
+  public String getDescription() {
+    return "Validates JodaBeans";
+  }
+  
+  @Override
+  protected int runTool(Class<?> toolClass, List<String> argsList) {
+    //intercepts the call to runTool, failing if in strict mode and files were updated by the tool
+    int filesUpdated = super.runTool(toolClass, argsList);
+    if (isStrict() && filesUpdated != 0) {
+      throw new GradleException(filesUpdated + "  beans need regenerating. See log."); 
+    } else {
+      return filesUpdated;
+    }
+  }
+  
 }


### PR DESCRIPTION
This change adds support for a _strict_ mode which causes the `jodaValidate` task to fail if beans need regenerating. Having the ability to fail the build is useful from a continuous integration point of view as it prevents beans from going stale.

It also adds group and description information for each task. This makes them appear as public tasks under a `JodaBeans` section when running `gradle tasks`. e.g.

```
$ ./gradlew tasks
...
JodaBeans tasks
---------------
jodaGenerate - Generates JodaBeans
jodaValidate - Validates JodaBeans
```
